### PR TITLE
Metgrid table restore

### DIFF
--- a/metgrib/METGRID.TBL.MEDCORDEX
+++ b/metgrib/METGRID.TBL.MEDCORDEX
@@ -202,7 +202,7 @@ name=SW010200
         flag_in_output=FLAG_SW010200
 ========================================
 name=SM000010
-        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        interp_option=four_pt+sixteen_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
         interp_mask=LANDSEA(0)
         missing_value=-1.E30
@@ -210,7 +210,7 @@ name=SM000010
         flag_in_output=FLAG_SM000010
 ========================================
 name=SM010035
-        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        interp_option=four_pt+sixteen_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
         interp_mask=LANDSEA(0)
         missing_value=-1.E30
@@ -218,7 +218,7 @@ name=SM010035
         flag_in_output=FLAG_SM010035
 ========================================
 name=SM010040
-        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        interp_option=four_pt+sixteen_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
         interp_mask=LANDSEA(0)
         missing_value=-1.E30
@@ -226,7 +226,7 @@ name=SM010040
         flag_in_output=FLAG_SM010040
 ========================================
 name=SM035100
-        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        interp_option=four_pt+sixteen_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
         interp_mask=LANDSEA(0)
         missing_value=-1.E30
@@ -234,7 +234,7 @@ name=SM035100
         flag_in_output=FLAG_SM035100
 ========================================
 name=SM040100
-        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        interp_option=four_pt+sixteen_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
         interp_mask=LANDSEA(0)
         missing_value=-1.E30
@@ -242,7 +242,7 @@ name=SM040100
         flag_in_output=FLAG_SM040100
 ========================================
 name=SM100200
-        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        interp_option=four_pt+sixteen_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
         interp_mask=LANDSEA(0)
         missing_value=-1.E30
@@ -250,7 +250,7 @@ name=SM100200
         flag_in_output=FLAG_SM100200
 ========================================
 name=SM100300
-        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        interp_option=four_pt+sixteen_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
         interp_mask=LANDSEA(0)
         missing_value=-1.E30
@@ -258,7 +258,7 @@ name=SM100300
         flag_in_output=FLAG_SM100300
 ========================================
 name=SM010200
-        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        interp_option=four_pt+sixteen_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
         interp_mask=LANDSEA(0)
         missing_value=-1.E30
@@ -388,91 +388,91 @@ name=ST100255
         flag_in_output=FLAG_ST100255
 ========================================
 name=SOILM000
-        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        interp_option=four_pt+sixteen_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
         interp_mask=LANDSEA(0)
         fill_missing=1.
         flag_in_output=FLAG_SOILM000
 ========================================
 name=SOILM001
-        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        interp_option=four_pt+sixteen_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
         interp_mask=LANDSEA(0)
         fill_missing=1.
         flag_in_output=FLAG_SOILM001
 ========================================
 name=SOILM004
-        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        interp_option=four_pt+sixteen_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
         interp_mask=LANDSEA(0)
         fill_missing=1.
         flag_in_output=FLAG_SOILM004
 ========================================
 name=SOILM005
-        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        interp_option=four_pt+sixteen_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
         interp_mask=LANDSEA(0)
         fill_missing=1.
         flag_in_output=FLAG_SOILM005
 ========================================
 name=SOILM010
-        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        interp_option=four_pt+sixteen_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
         interp_mask=LANDSEA(0)
         fill_missing=1.
         flag_in_output=FLAG_SOILM010
 ========================================
 name=SOILM020
-        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        interp_option=four_pt+sixteen_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
         interp_mask=LANDSEA(0)
         fill_missing=1.
         flag_in_output=FLAG_SOILM020
 ========================================
 name=SOILM030
-        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        interp_option=four_pt+sixteen_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
         interp_mask=LANDSEA(0)
         fill_missing=1.
         flag_in_output=FLAG_SOILM030
 ========================================
 name=SOILM040
-        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        interp_option=four_pt+sixteen_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
         interp_mask=LANDSEA(0)
         fill_missing=1.
         flag_in_output=FLAG_SOILM040
 ========================================
 name=SOILM060
-        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        interp_option=four_pt+sixteen_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
         interp_mask=LANDSEA(0)
         fill_missing=1.
         flag_in_output=FLAG_SOILM060
 ========================================
 name=SOILM100
-        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        interp_option=four_pt+sixteen_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
         interp_mask=LANDSEA(0)
         fill_missing=1.
         flag_in_output=FLAG_SOILM100
 ========================================
 name=SOILM160
-        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        interp_option=four_pt+sixteen_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
         interp_mask=LANDSEA(0)
         fill_missing=1.
         flag_in_output=FLAG_SOILM160
 ========================================
 name=SOILM300
-        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        interp_option=four_pt+sixteen_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
         interp_mask=LANDSEA(0)
         fill_missing=1.
         flag_in_output=FLAG_SOILM300
 ========================================
 name=SOILT000
-        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        interp_option=four_pt+sixteen_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
         interp_mask=LANDSEA(0)
         fill_missing=285.

--- a/tests/convert_year_2019.sh
+++ b/tests/convert_year_2019.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# this bash script convert 1 year of medcordex data
+export ATMDATA=/data/inputs/metocean/historical/model/atmos/IPSL/MedCordex/projections/atm_regional/2019
+export OCNDATA=/work/remhi/pm09220/medcordex/29_07_21
+export OUTPATH=/work/remhi/pm09220/medcordex/24_09_21/intermediate_out
+export LANDSEA_MASK_PATH=/work/remhi/pm09220/medcordex/24_09_21/medcordex_to_wps/data/phis_box.nc
+mkdir -p $OUTPATH
+module load ncl
+ncl ../src/mcordex2int.ncl


### PR DESCRIPTION
The native interpolation options are restored in metgrib table.
Only the soil moisture field is interpolated by a 4 pt interpolation option